### PR TITLE
Use pangeo-gallery/default-binder image

### DIFF
--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -4,6 +4,6 @@ description: >-
   An gallery of notebooks to introduce the Pangeo software stack.
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://mybinder.org"
-binder_repo: pangeo-data/pangeo-tutorial-gallery
+binder_repo: pangeo-gallery/default-binder
 binder_ref: master
 binderbot_target_branch: binderbot-built


### PR DESCRIPTION
Part of https://github.com/pangeo-gallery/pangeo-gallery/issues/30, to
aid in testing deployments.

This is a bit different, since it runs on mybinder rather than pangeo's
binders. But it's still probably good to use the default-binder image so
that we can run some tests when we update that image.